### PR TITLE
fix: Remove obsolete CartActivity declaration from AndroidManifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,9 +19,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity
-            android:name=".CartActivity"
-            android:exported="false" />
     </application>
 
 </manifest>


### PR DESCRIPTION
This commit removes a lingering `<activity>` declaration for a non-existent `CartActivity` from the `AndroidManifest.xml` file.

This declaration was a remnant from the original project structure before the application was rebuilt with a single-activity Jetpack Compose architecture. The presence of this invalid declaration was preventing the application from launching correctly and displaying the intended initial screen (`RoleSelectionScreen`).

Removing this declaration resolves the launch issue and allows the application to start as expected.